### PR TITLE
Feedback from Ray

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -62,13 +62,79 @@ The dataset contains information on household final consumption expenditure, whi
 
 In the model, the original consumption variable is log-transformed to reduce the scale and conform to the assumption of normality.
 
+```{r}
+# Data extraction and cleaning
+# Consumption and consumption growhth
+consumption.dl   <- read_rba(series_id = "GGDPECCVPSH")
+consumption <- to.quarterly(xts(consumption.dl$value, consumption.dl$date), 
+                         OHLC = FALSE)
+consumption_growth <- 100*diff(log(consumption))
+# real GDP
+realGDP.dl   <- read_rba(series_id = "GGDPCVGDP")
+realGDP <- to.quarterly(xts(realGDP.dl$value, realGDP.dl$date), 
+                         OHLC = FALSE)
+realGDP_growth <- 100*diff(log(realGDP))
 
+# nominal GDP, seasonally adjusted (in case you decide to use this instead)
+nomGDP.dl <- read_abs(series_id = "A2454486X")
+nomGDP <- to.quarterly(xts(nomGDP.dl$value, nomGDP.dl$date), 
+                         OHLC = FALSE)
+
+nomGDP_growth <- 100*diff(log(nomGDP))
+
+# real exchange rate (TWI)
+realTWI.dl   <- read_rba(series_id = "FRERTWI")
+realTWI <- to.quarterly(xts(realTWI.dl$value, realTWI.dl$date), 
+                         OHLC = FALSE)
+# Trade balance
+imports.dl <- read_abs(series_id = "A2454505V")
+imports <- to.quarterly(xts(imports.dl$value, imports.dl$date), 
+                         OHLC = FALSE)
+
+exports.dl <- read_abs(series_id = "A2454510L") 
+exports <- to.quarterly(xts(exports.dl$value, exports.dl$date), 
+                         OHLC = FALSE)
+# Inflation
+CPI.dl <- read_abs(series_id = "A2325846C")
+CPI <- to.quarterly(xts(CPI.dl$value, CPI.dl$date), 
+                         OHLC = FALSE)
+
+CPI_inflation.dl <- read_rba(series_id = "GCPIAGQP")
+CPI_inflation <- to.quarterly(xts(CPI_inflation.dl$value, CPI_inflation.dl$date), 
+                         OHLC = FALSE)
+
+# M3
+M3.dl   <- read_rba(series_id = "DMAM3N")
+M3 <- to.quarterly(xts(M3.dl$value, M3.dl$date), 
+                         OHLC = FALSE)
+# Government spending, seasonally adjusted
+pubcons.dl <- read_abs(series_id = "A2304036K")
+pubcons <- to.quarterly(xts(pubcons.dl$value, pubcons.dl$date),
+                         OHLC = FALSE)
+
+pubinv.dl <- read_abs(series_id = "A2304064V")
+pubinv <- to.quarterly(xts(pubinv.dl$value, pubinv.dl$date), 
+                         OHLC = FALSE)
+
+gov_spend <- pubcons + pubinv
+
+# matrix of endogenous variables 
+df <- na.omit(merge(consumption, realGDP, nomGDP,  realTWI, imports, exports, 
+                    CPI, M3, gov_spend))
+# transformed in log terms
+log_df <- log(df)
+
+#growth rates including inflation 
+growth_df <- na.omit(merge(consumption_growth, realGDP_growth, nomGDP_growth, CPI_inflation))
+
+```
 
 ```{r}
 consumption <- read_rba('H2')
 consumption$Date <- as.Date(consumption$date, format = "%Y-%m-%d")
 
 # Household final consumption expenditure measured in $million
+##plot(100*diff(df$log_con), type = "l")
 
 consumption2 <- consumption %>%
   filter(series_id == "GGDPECCVPSH") %>%

--- a/index.qmd
+++ b/index.qmd
@@ -117,42 +117,26 @@ pubinv <- to.quarterly(xts(pubinv.dl$value, pubinv.dl$date),
                          OHLC = FALSE)
 
 gov_spend <- pubcons + pubinv
+gov_spend_growth <- 100*diff(log(gov_spend))
 
 # matrix of endogenous variables 
 df <- na.omit(merge(consumption, realGDP, nomGDP,  realTWI, imports, exports, 
                     CPI, M3, gov_spend))
+
+df$Date <- as.vector(index(df))
 # transformed in log terms
 log_df <- log(df)
+log_df$Date <- as.vector(index(log_df))
 
 #growth rates including inflation 
-growth_df <- na.omit(merge(consumption_growth, realGDP_growth, nomGDP_growth, CPI_inflation))
-
+growth_df <- na.omit(merge(consumption_growth, realGDP_growth, nomGDP_growth, CPI_inflation, 
+                           gov_spend_growth))
+growth_df$Date <- as.vector(index(growth_df))
 ```
 
 ```{r}
-consumption <- read_rba('H2')
-consumption$Date <- as.Date(consumption$date, format = "%Y-%m-%d")
-
-# Household final consumption expenditure measured in $million
-##plot(100*diff(df$log_con), type = "l")
-
-consumption2 <- consumption %>%
-  filter(series_id == "GGDPECCVPSH") %>%
-  rename(consumption = value)
-
-df <- consumption2 %>% select(Date,consumption)
-# Consumption growth
-consumption3 <- consumption %>%
-  filter(series_id == "GGDPECCVPSHY") %>%
-  rename(consumption_growth = value) %>% select(Date,consumption_growth)
-
-df <- merge(df,consumption3,by="Date")
-
-df$log_con = log(df$consumption)
-
-
-# Plot the data
-plot1<- ggplot(data = df, aes(x = Date, y =log_con)) +
+# Consumption levels and growth plot
+plot1<- ggplot(data = log_df, aes(x = Date, y =consumption)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " Household Consumption (log)", x = "Year", y = "Index") +
   theme_bw() +
@@ -160,7 +144,7 @@ plot1<- ggplot(data = df, aes(x = Date, y =log_con)) +
         axis.title = element_text(size = 14, face = "bold"),
         axis.text = element_text(size = 12),
         legend.position = "none")
-plot2<- ggplot(data = df, aes(x = Date, y =consumption_growth)) +
+plot2<- ggplot(data = growth_df, aes(x = Date, y =consumption_growth)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " Household Consumption Growth", x = "Year", y = "Index") +
   theme_bw() +
@@ -169,8 +153,8 @@ plot2<- ggplot(data = df, aes(x = Date, y =consumption_growth)) +
         axis.text = element_text(size = 12),
         legend.position = "none")
 
-consumption_plot <- plot_grid(plot1, plot2,  ncol = 1, align = "v")
-print(consumption_plot)
+plot <- plot_grid(plot1, plot2,  ncol = 1, align = "v")
+print(plot)
 
 ```
 ### GDP
@@ -179,24 +163,9 @@ The real GDP is measured in million dollars, and the plot of this data suggests 
 
 When examining the plot of the GDP percentage change, it appears to be more stationary over time. However, the data fluctuates significantly during the COVID period. In a later section, I also run ACF and PACF tests, which suggest that I should keep the original variable.
 ```{r}
-# GDP
-GDP <- read_rba('H1')
-GDP$Date <- as.Date(GDP$date, format = "%Y-%m-%d")
-# Real GDP
+# GDP levels and growth plot
 
-GDP2 <- GDP %>%
-  filter(series_id == "GGDPCVGDP") %>%
-  rename(GDP = value) %>%
-  select(Date,GDP)
-
-df <- merge(df,GDP2, by="Date")
-
-df$log_gdp = log(df$GDP)
-
-# First difference for gdp
-df <- df %>% mutate(GDP_percentage = (GDP-lag(GDP))/lag(GDP)*100)
-
-plot2<- ggplot(data = df, aes(x = Date, y =log_gdp)) +
+plot2<- ggplot(data = log_df, aes(x = Date, y =realGDP)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " GDP (log)", x = "Year", y = "Index") +
   theme_bw() +
@@ -204,7 +173,7 @@ plot2<- ggplot(data = df, aes(x = Date, y =log_gdp)) +
         axis.title = element_text(size = 14, face = "bold"),
         axis.text = element_text(size = 12),
         legend.position = "none")
-plot3<- ggplot(data = df, aes(x = Date, y =GDP_percentage)) +
+plot3<- ggplot(data = growth_df, aes(x = Date, y =realGDP_growth)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " GDP percentage change", x = "Year", y = "Index") +
   theme_bw() +
@@ -213,30 +182,16 @@ plot3<- ggplot(data = df, aes(x = Date, y =GDP_percentage)) +
         axis.text = element_text(size = 12),
         legend.position = "none")
 
-consumption_plot <- plot_grid(plot2, plot3,  ncol = 1, align = "v")
-print(consumption_plot)
+plot <- plot_grid(plot2, plot3,  ncol = 1, align = "v")
+print(plot)
 
 ```
 ### Exchange rate
 
 The real exchange rate data is sourced from the Reserve Bank of Australia (RBA) and is provided on a quarterly basis. RBA uses the Australian dollar trade-weighted index as a measure of the real exchange rate. This index represents the price of the Australian dollar in terms of a group of foreign currencies, based on their share of trade with Australia.
 ```{r }
-
-
 # TWI 
-
-real_exchange_rate <- read_rba("F15")
-real_exchange_rate$Date <- as.Date(real_exchange_rate$date, format = "%Y-%m-%d")
-
-real_exchange_rate_twi <-   real_exchange_rate %>%
-  filter(series_id == "FRERTWI") %>%
-  rename(TWI = value) %>%
-  select(Date,TWI)
-  
-df <- merge(df,real_exchange_rate_twi, by='Date')
-
-
-plot5<- ggplot(data = df, aes(x = Date, y =TWI)) +
+plot5<- ggplot(data = df, aes(x = Date, y =realTWI)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " Real exchange rate (TWI)", x = "Year", y = "Index") +
   theme_bw() +
@@ -247,12 +202,6 @@ plot5<- ggplot(data = df, aes(x = Date, y =TWI)) +
 
 print(plot5)
 ```
-
-
-
-
-
-
 Additionally, I also investigate the nominal exchange rate variable. I download the AUD/USD exchange rate, as the US dollar is widely accepted as an international currency. (Note: The data obtained using the package may not exactly match the description on the website.) However, since the nominal exchange rate may be influenced by various factors and due to data availability constraints, this research will focus exclusively on the real interest rate (TWI).
 
 
@@ -263,19 +212,11 @@ The trade balance data is measured as a percentage of output and is recorded on 
 
 
 ```{r}
-Trade_balance <- read_rba("I1")
 
-Trade_balance$Date <- as.Date(Trade_balance$date, format = "%Y-%m-%d")
-
-Trade_balance2 <- Trade_balance   %>%
-filter(series_id == "HTBGSCPGDP") %>%
-  rename(Trade_balance = value) %>%
-  select(Date,Trade_balance)
-df <- merge(df,Trade_balance2,by = "Date")
-
-plot6<- ggplot(data = df, aes(x = Date, y =Trade_balance)) +
-  geom_line(color = "steelblue", size = 0.8) +
-  labs(title = " Trade Balance", x = "Year", y = "Index") +
+plot6<- ggplot(data = log_df, aes(x = Date)) +
+  geom_line(aes(y = exports-imports), color = "steelblue", size = 0.8) +
+  #geom_line(aes(y = imports), color = "firebrick", size = 0.8) +
+  labs(title = " Trade Balance (log)", x = "Year", y = "Index") +
   theme_bw() +
   theme(plot.title = element_text(size = 16, hjust = 0.5, face = "bold"),
         axis.title = element_text(size = 14, face = "bold"),
@@ -291,8 +232,6 @@ print(plot6)
 
 ```{r}
 CPI = read_rba("G1")
-
-
 
 inflation <- CPI %>%
   filter(series_id == "GCPIAGQP") %>%
@@ -340,27 +279,7 @@ df = merge(df,M3_quarterly_df, by= "Date")
 ### government spending data
 Due to package constraints, readrba or readabs are not applicable for government spending data, as the data published about the public sector by ABS is yearly. Instead, I use FRED as my data source. Government spending is increasing due to the upward trend, so I use the lag() function to transform this data.  I will keep the lof transformation of the original variable.
 ```{r}
-# Set your FRED API key
-
-readRenviron("secret.R")
-api_key <-Sys.getenv("MY_FRED_API_KEY")
-fredr_set_key(api_key)
-
-# Download the Australian government spending data (quarterly data, seasonally adjusted)
-gov_spending_australia <- fredr(series_id = "AUSGFCEQDSMEI",observation_start = as.Date("1970-01-01"))
-
-#  Real General Government Final Consumption Expenditure for Australia 
-gov_spending_australia <- fredr(series_id = "NCGGRSAXDCAUQ",observation_start = as.Date("1970-01-01"))
-
-
-gov_spending_australia$log_gov = log(gov_spending_australia$value)
-
-gov_spending_australia <- gov_spending_australia %>%
-  mutate(percentage_change = (value - lag(value)) / lag(value) * 100) %>% 
-select(date,value,percentage_change,log_gov) %>%
-  rename(Date = date)
-
-plot7<- ggplot(data = gov_spending_australia, aes(x = Date, y =log_gov)) +
+plot7<- ggplot(data = log_df, aes(x = Date, y =gov_spend)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " Government Spending", x = "Year", y = "Index") +
   theme_bw() +
@@ -369,7 +288,7 @@ plot7<- ggplot(data = gov_spending_australia, aes(x = Date, y =log_gov)) +
         axis.text = element_text(size = 12),
         legend.position = "none")
 
-plot8<- ggplot(data = gov_spending_australia, aes(x = Date, y =percentage_change)) +
+plot8<- ggplot(data = growth_df, aes(x = Date, y =gov_spend_growth)) +
   geom_line(color = "steelblue", size = 0.8) +
   labs(title = " Government Spending percentage change", x = "Year", y = "Index") +
   theme_bw() +

--- a/index.qmd
+++ b/index.qmd
@@ -382,24 +382,31 @@ for (i in seq_along(data_without_date)) {
 
 
 ## Model Specification 
-Using same notations in lecture, the model is specified as follows:
-$$B_0 y_t = b_0 + B_1 y_{t-1}+ ... + B_p y_{t-p}+u_t$$
-Then the empirical model for this study is a structural vector autoregression of the reduced form representation
+The structural model is specified as follows:
+$$\begin{align}
+B_0y_t &= b_0 + B_1 y_{t-1} + \dots + B_p y_{t-p} + u_t\\
+u_{t}| Y_{t-1} &\sim _{iid} ( 0, I_N)
+\end{align}$$
 
-$$  \begin{bmatrix} \hat{g_t} \\   \hat{c_t} \\ \hat{y_t} \\ \hat{e}_t \\ \hat{i}_t  \\ \hat{m}_t \end{bmatrix} = A(L) \begin{bmatrix} \hat{g}_{t-1} \\   \hat{c}_{t-1} \\ \hat{y}_{t-1} \\ \hat{e}_{t-1} \\\hat{i}_{t-1  }\\ \hat{m}_{t-1} \end{bmatrix} + \varepsilon_t $$
+Then the empirical model for this study is a structural vector autoregression of the reduced form representation:
+
+$$\begin{align}
+y_t &= \mu_0 + A_1 y_{t-1} + \dots + A_p y_{t-p} + \varepsilon_t\\
+\text{where }B_0^{-1}u_t &= \varepsilon_t| Y_{t-1} \sim _{iid} ( 0, \Sigma)\\
+\Sigma &= B_0^{-1}B_0^{-1'}
+\end{align}$$
+
 Where:
 
-$g_t$ denotes real government spending,
-
-$c_t$ denotes household final consumption,
-
-$y_t$ denotes real GDP,
-
-$e_t$ denotes the real exchange rate (trade-weighted index),
-$i_t$ denotes the inflation,
-$m_t$ denotes the M3. 
-
-$A(L)$ is an nxn matrix polynomial in the lag operator L, representing the dynamic relationships among the endogenous variables,
+$$y_t=\begin{pmatrix}  govspend_t &= \text{government spending}
+\\ consump_t  &= \text{consumption}
+\\ realGDP_t  &= \text{real GDP}
+\\ TWI_t  &= \text{real exchange rate (trade-weighted index)}
+\\ CPI_t  &= \text{consumer price index}
+\\ export_t  &= \text{exports}
+\\ imports_t  &= \text{imports}
+\\ M3_t  &= \text{M3 money supply}
+\end{pmatrix}$$
 
 $\varepsilon_t$ is a vector of the structural shocks at time t: $\varepsilon_t = [\varepsilon_{g_t}, \varepsilon_{c_t}, \varepsilon_{y_t}, \varepsilon_{e_t}]^T$.
 


### PR DESCRIPTION
Hello @mantihuang 

Thank you very much for the interesting read! Please find my comments and suggestions on your research project:

I think the research topic is well-motivated. While the effect of fiscal policy on output and consumption is often analyzed (particularly by economic managers of governments globally) the role of the external sector in magnifying or mitigating the effects of fiscal stimuli may often be overlooked. As such, I feel that your research provides a more holistic and robust framework for studying and calibrating fiscal policy.

However, the linkages between fiscal policy, output/consumption, and the external sector may be quite complex. As such the proposal may benefit from further elaboration on economic theory behind the role of external sector on the effectiveness of fiscal policy. In particular, the theoretical mechanisms that relate fiscal policy, output and the external sector could be discussed. Below are some suggested ideas for expanding the Motivation section:
- [x] Clarify that it is under the Keynesian economic framework that expansionary fiscal policy affects output in the short run before output returns to a “natural level” in the medium-to-long term.  Long-run models (e.g., Cobb-Douglas model) argue that long-run growth per se is a function of supply side factors such as capital accumulation and technological growth, not isolated demand shocks.
- [x] Layout the links between fiscal policy, output, and trade balance. The relationship between these three in the short run may be discussed through the lens of the reduced fiscal multiplier in an open economy. In short, under an open economy setting, the increase in demand from a fiscal shock will be “split” between domestic and foreign goods, boosting domestic output but deteriorating the trade balance (from higher imports), culminating in a “dampened” the effect of fiscal policy stimuli/weaker multiplier. These mechanisms may become apparent in your results say you find a small effect on output but large effect on imports.
- [x] Acknowledge that Australia has a floating exchange rate policy and so it could mainly driven by (domestic and foreign) interest rates and expectations. This could be show up in the results as a small or insignificant effect of fiscal policy on exchange rates. The effect of exchange rates on output and consumption however may be more apparent. For example, a real depreciation (e.g., from lowering of interest rates) is expected to boost the trade balance and output.
- [x] Instead of using the debt-to-GDP ratio, use macroeconomic statistics other since this variable is not discussed in subsequent parts of the paper. Perhaps using the growth in government spending could be more appropriate. 

Regarding the .qmd file, I have the following suggestions that may improve your data extraction, cleaning and merging code as well as some cosmetic revisions to the model specification section:

_Data extraction, cleaning, and merging_
- [x] Consolidate data extractions in one code block at the top. Since the RBA website is glitchy, it might be better to run  the extractions altogether.
- [x] Compute growth rates quickly as the first difference of log terms using `log` and `diff` functions in R
- [x] Merge various extracted variables into one dataframe at once before proceeding to plots (instead appending new variables one at a time to the dataframe)
- [x] Use ABS data for government spending instead of Fred (I encountered some errors). Moreover, I am unsure of how government spending is defined in Fred, but in many national accounts, government investments (i.e., public gross fixed capital formation) is typically included in total investment (“I”), not in government consumption (“G”). As such, government GFCF + government consumption might be a better representation of “government spending”. 
- [x] Use nominal GDP instead of real GDP since government spending will be in nominal terms, trade balance is measured as a percentage of output (i.e., nominal GDP) and since inflation is included which will be more correlated with real GDP than nominal GDP.
- [x] Use imports and exports variables instead of trade balance. The raw trade balance data is in terms of nominal GDP with some observations yielding a value of zero. Even if we extrapolate the value in nominal terms by TB x nominal GDP, the 0 observations will still yield a null value. This is problematic once we take the logs since ln(0) = undefined. We find a similar issue for negative trade balance values (since the log function is only defined at postive inputs). 
- [x] Put growth rates and inflation variables in a separate matrix since these sometimes have negative values and yield undefined values when log-transformed. It might be better to use levels values only in the final matrix of endogenous variables.
- [x] Revise time series plots, P/ACF, plots and ADF test codes accordingly to link up with revised data frames. I ran your ggplot codes with these revised dataframes it seemed to work fine.

The above suggested changes are executed in the following commits, in case you would want to implement them: 8d0e66d9497ed58609907249461f9a356ec761db 735dd93787ee97bb7ae07bcf3531a3d22d581098


_Model specification notation_

- [x] Include imports and exports in the stated variables (in case omitting the trade balance was unintentional)
- [x] Change variable names to be more descriptive. Also $y_t$ is used as both the vector of endonous variables as well as the variable name for GDP which might be confusing. 
- [x] Express the  reduced form error term as a function of the structural error term and the relationships matrix, just to allow readers to follow more smoothly.

The above changes are also exucuted in the following commit, for your reference: b34257450d80db22a955765b5a7d2bd874ab7d8c

For your consideration.

Cheers,
Ray