### PR TITLE
you need a sharper shrinkage!

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -585,7 +585,7 @@ Posterior <- function(Y, X, p, N, S) {
   
   # prior distribution
   ############################################################
-  kappa.1     = 1^2
+  kappa.1     = 0.01
   kappa.2     = 100
   kappa.3     = 1
   A.prior     = matrix(0,nrow(A.hat),ncol(A.hat))


### PR DESCRIPTION
Hey @mantihuang 

I propose to generate results using a much sharper shrinkage for the `A` matrix. This usually helps to constrain explosive IRFs. 

You could try with different values for `kappa.1` :) That's why we estimate the shrinkage parameter - that is - to avoid the grid search until things go well. But maybe you'll be lucky the first time!

Let me know how it works :a: