### PR TITLE
corrected IRF computations code

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1059,7 +1059,7 @@ for (s in 1:S){
     if (i==1){
       IRF.posterior[,,i,s]        = B.posterior[,,s]
     } else {
-      IRF.posterior[,,i,s]        = J %*% A.bold.power %*% t(J) %*% IRF.posterior[,,i-1,s]
+      IRF.posterior[,,i,s]        = J %*% A.bold.power %*% t(J) %*% B.posterior[,,s]
       A.bold.power                = A.bold.power %*% A.bold
     }
     for (n in 1:N){


### PR DESCRIPTION
Hey @mantihuang 

There might be other problems as well, but this one must have been part of the whole issue!

Would you consider working only on matrices `A` and `B` and never compute `B_0` and `B_1`? They are not really needed at all in your approach, and the back-and-forth transformations only expose one to the possibility of more bugs.

Greetings,

T